### PR TITLE
handle guild create and delete events

### DIFF
--- a/bot/src/events/guild-create.ts
+++ b/bot/src/events/guild-create.ts
@@ -1,0 +1,14 @@
+import {db} from 'db'
+import type {Event} from '../types'
+
+export const guildCreate: Event<'guildCreate'> = {
+  name: 'guildCreate',
+  listener: async (guild) => {
+    console.log(`Joined guild ${guild.name} (${guild.id})`)
+    await db.guild.create({
+      data: {
+        guildSnowflake: guild.id,
+      },
+    })
+  },
+}

--- a/bot/src/events/guild-delete.ts
+++ b/bot/src/events/guild-delete.ts
@@ -1,0 +1,14 @@
+import {db} from 'db'
+import type {Event} from '../types'
+
+export const guildDelete: Event<'guildDelete'> = {
+  name: 'guildDelete',
+  listener: async (guild) => {
+    console.log(`Left guild ${guild.name} (${guild.id})`)
+    await db.guild.delete({
+      where: {
+        guildSnowflake: guild.id,
+      },
+    })
+  },
+}

--- a/bot/src/events/index.ts
+++ b/bot/src/events/index.ts
@@ -1,4 +1,6 @@
+import {guildCreate} from './guild-create'
+import {guildDelete} from './guild-delete'
 import {interactionCreate} from './interaction-create'
 import {ready} from './ready'
 
-export const events = [ready, interactionCreate]
+export const events = [ready, interactionCreate, guildCreate, guildDelete]

--- a/db/prisma/migrations/20220417022713_cascading_delete/migration.sql
+++ b/db/prisma/migrations/20220417022713_cascading_delete/migration.sql
@@ -1,0 +1,25 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ReactionRole" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "guildId" INTEGER NOT NULL,
+    "text" TEXT NOT NULL,
+    "channelSnowflake" TEXT NOT NULL,
+    "messageSnowflake" TEXT,
+    CONSTRAINT "ReactionRole_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_ReactionRole" ("channelSnowflake", "guildId", "id", "messageSnowflake", "text") SELECT "channelSnowflake", "guildId", "id", "messageSnowflake", "text" FROM "ReactionRole";
+DROP TABLE "ReactionRole";
+ALTER TABLE "new_ReactionRole" RENAME TO "ReactionRole";
+CREATE TABLE "new_ReactionRoleOption" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "roleSnowflake" TEXT NOT NULL,
+    "emoji" TEXT NOT NULL,
+    "reactionRoleId" INTEGER NOT NULL,
+    CONSTRAINT "ReactionRoleOption_reactionRoleId_fkey" FOREIGN KEY ("reactionRoleId") REFERENCES "ReactionRole" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_ReactionRoleOption" ("emoji", "id", "reactionRoleId", "roleSnowflake") SELECT "emoji", "id", "reactionRoleId", "roleSnowflake" FROM "ReactionRoleOption";
+DROP TABLE "ReactionRoleOption";
+ALTER TABLE "new_ReactionRoleOption" RENAME TO "ReactionRoleOption";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Guild {
 model ReactionRole {
   id               Int                  @id @default(autoincrement())
   guildId          Int
-  guild            Guild                @relation(fields: [guildId], references: [id])
+  guild            Guild                @relation(fields: [guildId], references: [id], onDelete: Cascade)
   text             String
   channelSnowflake String
   messageSnowflake String?
@@ -29,5 +29,5 @@ model ReactionRoleOption {
   /// `emoji` is either a unicode emoji (built-in) or a `Snowflake` (custom)
   emoji          String
   reactionRoleId Int
-  reactionRole   ReactionRole @relation(fields: [reactionRoleId], references: [id])
+  reactionRole   ReactionRole @relation(fields: [reactionRoleId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
This PR closes #17 and closes #16. It implements two events:

- `guildCreate`: when the bot joins a server. we create a new `Guild` in the `db` and store its `Snowflake`
- `guildDelete`: when the bot is removed from a server. we use the guild's `Snowflake` to delete its entry in the database

I also enabled cascading delete on `ReactionRole` and `ReactionRoleOption`, so that when a `Guild` is deleted, those relevant model entries will be deleted with it.