### PR TITLE
create missing reaction roles messages on `ready`

### DIFF
--- a/.changeset/old-games-yell.md
+++ b/.changeset/old-games-yell.md
@@ -1,0 +1,9 @@
+---
+'bot': minor
+---
+
+When the bot opens an initial connection, it will now search for reaction roles
+that don't have a corresponding Discord message and create one.
+
+This means reaction roles created while the bot is offline while still be
+handled when the bot comes back online.

--- a/bot/src/events/ready.ts
+++ b/bot/src/events/ready.ts
@@ -1,9 +1,14 @@
+import {createMissingReactionRolesMessages} from '../lib'
 import type {Event} from '../types'
 
 export const ready: Event<'ready'> = {
   name: 'ready',
   once: true,
-  listener: (client) => {
+  listener: async (client) => {
     console.log(`Ready! Logged in as ${client.user.tag}`)
+
+    // create messages for any reaction roles that don't yet have a
+    // corresponding Discord message
+    await createMissingReactionRolesMessages(client)
   },
 }

--- a/bot/src/lib.ts
+++ b/bot/src/lib.ts
@@ -1,0 +1,67 @@
+import type {ReactionRole, ReactionRoleOption} from 'db'
+import {db} from 'db'
+import type {Client, TextChannel} from 'discord.js'
+
+/**
+ * Search the database for `ReactionRoles` configurations that are missing a
+ * Discord message and create them.
+ */
+export async function createMissingReactionRolesMessages(client: Client) {
+  const missingReactionRoles = await db.reactionRole.findMany({
+    where: {
+      messageSnowflake: null,
+    },
+    include: {
+      options: true,
+    },
+  })
+
+  if (missingReactionRoles.length === 0) return
+
+  console.log(
+    `Creating ${missingReactionRoles.length} missing reaction roles messages`,
+  )
+
+  await Promise.all(
+    missingReactionRoles.map(async (reactionRole) =>
+      createReactionRoleMessage(client, reactionRole),
+    ),
+  )
+}
+
+/**
+ * Create a Discord message for a `ReactionRole` configuration.
+ */
+export async function createReactionRoleMessage(
+  client: Client,
+  reactionRole: ReactionRole & {options: ReactionRoleOption[]},
+) {
+  const channel = client.channels.cache.get(
+    reactionRole.channelSnowflake,
+  ) as TextChannel
+
+  console.log(
+    `Creating message for reaction role ${reactionRole.id} in channel ${channel.id}`,
+  )
+
+  const message = await channel.send(reactionRole.text)
+
+  await db.reactionRole.update({
+    where: {
+      id: reactionRole.id,
+    },
+    data: {
+      messageSnowflake: message.id,
+    },
+  })
+
+  await Promise.all(
+    reactionRole.options.map(async (option) => {
+      await message.react(option.emoji)
+    }),
+  )
+
+  console.log(
+    `Added ${reactionRole.options.length} reactions to message ${message.id}`,
+  )
+}


### PR DESCRIPTION
This PR closes #12 by creating missing reaction roles messages on `ready`.

When the `ready` event occurs, we search the `db` for any `ReactionRole` entries where `messageSnowflake` is `null` (meaning we haven't created a corresponding Discord message yet). For each valid entry, we send a message in the corresponding guild+channel, save the message's `Snowflake` in the `db`, and then add an emoji reaction to the message for each `ReactionRoleOption`.