### PR TITLE
enable Discord authentication in `webapp`

### DIFF
--- a/.changeset/weak-doors-reflect.md
+++ b/.changeset/weak-doors-reflect.md
@@ -1,0 +1,41 @@
+---
+'webapp': minor
+---
+
+Enabled Discord authentication in the app. This allows us to store and later
+retrieve the current user's Discord access token which will enable us to make
+calls to the Discord API.
+
+To retrieve session data in a React component or hook, use the `useSession` hook
+from `next-auth/react`:
+
+```tsx
+import {useSession} from 'next-auth/react'
+
+const Example = () => {
+  const {data: session} = useSession()
+
+  return <p>Hello, {session.user.name}!</p>
+}
+```
+
+To retrieve session data outside of React, use the `getSession` function from
+`next-auth/react`:
+
+```tsx
+import {getSession} from 'next-auth/react'
+
+export default async function getUserDetails(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getSession({req: request})
+
+  if (!session) {
+    // no session; user needs to be authenticated
+    return res.status(401)
+  }
+
+  return res.status(200).
+}
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,12 @@ importers:
       '@types/react-dom': 18.0.1
       eslint-config-next: 12.1.5
       next: 12.1.5
+      next-auth: ^4.3.3
       react: 18.0.0
       react-dom: 18.0.0
     dependencies:
       next: 12.1.5_cba0cb7a45c5be1acc73e969c348db7f
+      next-auth: 4.3.3_react-dom@18.0.0+react@18.0.0
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
     devDependencies:
@@ -846,6 +848,10 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+
+  /@panva/hkdf/1.0.1:
+    resolution: {integrity: sha512-mMyQ9vjpuFqePkfe5bZVIf/H3Dmk6wA8Kjxff9RcO4kqzJo+Ek9pGKwZHpeMr7Eku0QhLXMCd7fNCSnEnRMubg==}
+    dev: false
 
   /@preconstruct/cli/2.1.5:
     resolution: {integrity: sha512-bMnGTkaotxq+xoOkXoUOfTFvxBX/ZUxukcacf3mx3G7Iz5m/T4ZGzSOU12pxl64e+rVWGTKlUsgaDSgyFkup0A==}
@@ -1752,6 +1758,11 @@ packages:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
       safe-buffer: 5.1.2
+    dev: false
+
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
     dev: false
 
   /core-js-pure/3.22.0:
@@ -2876,6 +2887,10 @@ packages:
       supports-color: 7.2.0
     dev: false
 
+  /jose/4.7.0:
+    resolution: {integrity: sha512-DJNm2vlcVW+0Fhl5LVxdhXK5Nw5VYZvL79uiq3ZCRm6vqzTuEVT9T5lIRfzmkGbaaiV+edefGog25TWVyJ4mRQ==}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3163,6 +3178,30 @@ packages:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: false
 
+  /next-auth/4.3.3_react-dom@18.0.0+react@18.0.0:
+    resolution: {integrity: sha512-bUs+oOOPT18Pq/+4v9q4PA/DGoVoAX6jwY7RTfE/akFXwlny+y/mNS6lPSUwpqcHjljqBaq34PQA3+01SdOOPw==}
+    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
+    peerDependencies:
+      nodemailer: ^6.6.5
+      react: ^17.0.2 || ^18.0.0-0
+      react-dom: ^17.0.2 || ^18.0.0-0
+    peerDependenciesMeta:
+      nodemailer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@panva/hkdf': 1.0.1
+      cookie: 0.4.2
+      jose: 4.7.0
+      oauth: 0.9.15
+      openid-client: 5.1.5
+      preact: 10.7.1
+      preact-render-to-string: 5.1.21_preact@10.7.1
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
+      uuid: 8.3.2
+    dev: false
+
   /next/12.1.5_cba0cb7a45c5be1acc73e969c348db7f:
     resolution: {integrity: sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==}
     engines: {node: '>=12.22.0'}
@@ -3256,10 +3295,19 @@ packages:
       npm-normalize-package-bin: 1.0.1
     dev: false
 
+  /oauth/0.9.15:
+    resolution: {integrity: sha1-vR/vr2hslrdUda7VGWQS/2DPucE=}
+    dev: false
+
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /object-hash/2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -3312,10 +3360,25 @@ packages:
       es-abstract: 1.19.5
     dev: true
 
+  /oidc-token-hash/5.0.1:
+    resolution: {integrity: sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+    dev: false
+
   /once/1.4.0:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
+
+  /openid-client/5.1.5:
+    resolution: {integrity: sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==}
+    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
+    dependencies:
+      jose: 4.7.0
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.0.1
+    dev: false
 
   /optionator/0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
@@ -3494,6 +3557,19 @@ packages:
       source-map-js: 1.0.2
     dev: false
 
+  /preact-render-to-string/5.1.21_preact@10.7.1:
+    resolution: {integrity: sha512-wbMtNU4JpfvbE04iCe7BZ1yLYN8i6NRrq+NhR0fUINjPXGu3ZIc4GM5ScOiwdIP1sPXv9SVETuud/tmQGMvdNQ==}
+    peerDependencies:
+      preact: '>=10'
+    dependencies:
+      preact: 10.7.1
+      pretty-format: 3.8.0
+    dev: false
+
+  /preact/10.7.1:
+    resolution: {integrity: sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==}
+    dev: false
+
   /preferred-pm/3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
     engines: {node: '>=10'}
@@ -3519,6 +3595,10 @@ packages:
     resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: false
+
+  /pretty-format/3.8.0:
+    resolution: {integrity: sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=}
     dev: false
 
   /prisma/3.12.0:
@@ -4099,6 +4179,11 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
+    dev: false
+
+  /uuid/8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
     dev: false
 
   /v8-compile-cache/2.3.0:

--- a/webapp/components/auth.tsx
+++ b/webapp/components/auth.tsx
@@ -1,0 +1,17 @@
+import {signIn, useSession} from 'next-auth/react'
+import {ReactNode} from 'react'
+
+export const Auth = ({children}: {children: ReactNode}) => {
+  const {data: session} = useSession()
+
+  if (session) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      Not signed in <br />
+      <button onClick={() => signIn()}>Sign in</button>
+    </>
+  )
+}

--- a/webapp/components/auth.tsx
+++ b/webapp/components/auth.tsx
@@ -1,8 +1,14 @@
 import {signIn, useSession} from 'next-auth/react'
-import {ReactNode} from 'react'
+import {ReactNode, useEffect} from 'react'
 
 export const Auth = ({children}: {children: ReactNode}) => {
   const {data: session} = useSession()
+
+  useEffect(() => {
+    if (session?.error === 'RefreshAccessTokenError') {
+      signIn()
+    }
+  }, [session])
 
   if (session) {
     return <>{children}</>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "12.1.5",
+    "next-auth": "^4.3.3",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },

--- a/webapp/pages/_app.tsx
+++ b/webapp/pages/_app.tsx
@@ -1,7 +1,15 @@
+import {SessionProvider} from 'next-auth/react'
 import type {AppProps} from 'next/app'
+import {Auth} from '../components/auth'
 
-function MyApp({Component, pageProps}: AppProps) {
-  return <Component {...pageProps} />
+function MyApp({Component, pageProps: {session, ...pageProps}}: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Auth>
+        <Component {...pageProps} />
+      </Auth>
+    </SessionProvider>
+  )
 }
 
 export default MyApp

--- a/webapp/pages/api/auth/[...nextauth].ts
+++ b/webapp/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,14 @@
+import NextAuth from 'next-auth'
+import DiscordProvider from 'next-auth/providers/discord'
+
+const SCOPES = ['identify'].join(' ')
+
+export default NextAuth({
+  providers: [
+    DiscordProvider({
+      clientId: process.env.DISCORD_CLIENT_ID,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET,
+      authorization: {params: {scope: SCOPES}},
+    }),
+  ],
+})

--- a/webapp/pages/api/auth/[...nextauth].ts
+++ b/webapp/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth'
+import {JWT} from 'next-auth/jwt'
 import DiscordProvider from 'next-auth/providers/discord'
 
 const SCOPES = ['identify'].join(' ')
@@ -11,4 +12,73 @@ export default NextAuth({
       authorization: {params: {scope: SCOPES}},
     }),
   ],
+  callbacks: {
+    async jwt({token, account, user}) {
+      // initial sign in
+      if (account && user) {
+        return {
+          accessToken: account.access_token,
+          accessTokenExpires: account.expires_at! * 1000,
+          refreshToken: account.refresh_token,
+          user,
+        }
+      }
+
+      // return existing token because it's not expired
+      if (Date.now() < (token.accessTokenExpires as number)) {
+        return token
+      }
+
+      // token expired so try to update it
+      return refreshAccessToken(token)
+    },
+    async session({session, token}) {
+      // @ts-expect-error
+      session.user = token.user
+      session.accessToken = token.accessToken
+      session.error = token.error
+
+      return session
+    },
+  },
 })
+async function refreshAccessToken(token: JWT) {
+  try {
+    const url = 'https://discord.com/api/oauth2/token'
+    const body = new URLSearchParams({
+      client_id: process.env.DISCORD_CLIENT_ID!,
+      client_secret: process.env.DISCORD_CLIENT_SECRET!,
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken as string,
+    }).toString()
+
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      method: 'POST',
+    })
+
+    const refreshedTokens = await response.json()
+
+    if (!response.ok) {
+      throw refreshedTokens
+    }
+
+    return {
+      ...token,
+      accessToken: refreshedTokens.access_token,
+      accessTokenExpires:
+        Date.now() + (refreshedTokens.expires_in as number) * 1000,
+      refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
+    }
+  } catch (error) {
+    console.error(error)
+
+    return {
+      ...token,
+      error: 'RefreshAccessTokenError',
+    }
+  }
+}

--- a/webapp/pages/index.tsx
+++ b/webapp/pages/index.tsx
@@ -1,7 +1,10 @@
 import type {NextPage} from 'next'
+import {useSession} from 'next-auth/react'
 import Head from 'next/head'
 
 const Home: NextPage = () => {
+  const session = useSession().data!
+
   return (
     <div>
       <Head>
@@ -12,6 +15,7 @@ const Home: NextPage = () => {
 
       <main>
         <h1>Discord Bot Webapp</h1>
+        <p>Hello, {session.user!.name}!</p>
       </main>
     </div>
   )


### PR DESCRIPTION
This PR closes #30 by:

- setting up a `next-auth` endpoint using `DiscordProvider` that handles token refreshing
- creating an `Auth` component that wraps our app so users can be required to log in

I also added a very simple greeting to `pages/index.tsx` to demonstrate how to get user information from the session.